### PR TITLE
client 增加开启http服务， 接受post的metric的功能

### DIFF
--- a/client/builtin/fd.go
+++ b/client/builtin/fd.go
@@ -30,6 +30,7 @@ func fdMetrics(cycle int) []*types.TimeSeriesData {
 	if err != nil {
 		return nil
 	}
+	defer fd.Close()
 	ts := time.Now().Unix()
 	r := bufio.NewReader(fd)
 	line, err := r.ReadString('\n')

--- a/client/http.go
+++ b/client/http.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"owl/common/types"
+	"time"
+)
+
+func startHttpMetrcs() {
+	if GlobalConfig.MetricBind != "0" {
+		http.HandleFunc("/", metricsHandler)
+		lg.Info("start http listen on: %s", GlobalConfig.MetricBind)
+		err := http.ListenAndServe(GlobalConfig.MetricBind, nil)
+		lg.Error("start metric interface error: %s", err)
+	} else {
+		return
+	}
+}
+
+func metricsHandler(w http.ResponseWriter, r *http.Request) {
+	var tsd types.TimeSeriesData
+	if r.Body == nil {
+		http.Error(w, "Please send a request body", 400)
+		return
+	}
+	err := json.NewDecoder(r.Body).Decode(&tsd)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"status":"%s"}`, err.Error()), 400)
+		return
+	}
+	tsd.Timestamp = time.Now().Unix()
+	lg.Info("get json data", tsd)
+	agent.SendChan <- tsd
+
+	w.Write([]byte(`{"status":"ok"}`))
+
+}

--- a/client/http.go
+++ b/client/http.go
@@ -5,11 +5,21 @@ import (
 	"fmt"
 	"net/http"
 	"owl/common/types"
+	"strings"
 	"time"
 )
 
 func startHttpMetrcs() {
-	if GlobalConfig.MetricBind != "0" {
+	var port string
+	mblist := strings.Split(GlobalConfig.MetricBind, ":")
+	if len(mblist) == 2 {
+		port = mblist[1]
+	} else {
+		lg.Error("metric_bind in the config file is incorrect")
+		return
+	}
+
+	if port != "0" {
 		http.HandleFunc("/", metricsHandler)
 		lg.Info("start http listen on: %s", GlobalConfig.MetricBind)
 		err := http.ListenAndServe(GlobalConfig.MetricBind, nil)

--- a/client/main.go
+++ b/client/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
@@ -25,10 +24,6 @@ func main() {
 		fmt.Println("failed to init logfile.")
 		return
 	}
-	go func() {
-		fmt.Printf("start metric interface %s\n", GlobalConfig.MetricBind)
-		fmt.Printf("%s\n", http.ListenAndServe(GlobalConfig.MetricBind, nil))
-	}()
 	if err = InitAgent(); err != nil {
 		fmt.Println(err)
 		return
@@ -43,5 +38,6 @@ func main() {
 	go agent.SendTSD2Repeater()
 	go agent.sendHeartbeat2Repeater()
 	go agent.syncMetricToCFC()
+	go startHttpMetrcs()
 	select {}
 }


### PR DESCRIPTION
client增加http接收metrics功能。在配置配置文端口号不为0开启。例如：关闭此功能：metric_bind=127.0.0.1:0。开启此功能：metric_bind=127.0.0.1:10057

python的post数据的例子：


```
#!/usr/bin/env python
# -*- coding: utf-8 -*-
# @Date    : 2018/10/21
# @Author  :  ()
# @Version : $

import requests
import time

data = {
    "metric": "my.system.cpu.softirq",
    "data_type": "GAUGE",
    "value": 355.53,
    "cycle": 60,
    "tags": {
        "cpu": "cpu-total66"
    }
}

for i in range(0, 1000):
    data["value"] = i
    re = requests.post("http://127.0.0.1:10057/", json=data)
    print (data)
    print (re.content)
    time.sleep(60)

```



