### PR TITLE
fix: correct sucessfully to successfully typo in logout message

### DIFF
--- a/src/api/users.go
+++ b/src/api/users.go
@@ -329,7 +329,7 @@ func Logout(c *gin.Context) {
 		}
 	}
 	c.SetCookie("token", "", -1, "/", "", false, true)
-	c.JSON(http.StatusOK, gin.H{"code": http.StatusUnauthorized, "link": "/", "message": "logout sucessfully"})
+	c.JSON(http.StatusOK, gin.H{"code": http.StatusUnauthorized, "link": "/", "message": "logout successfully"})
 }
 
 func iamLogout(token *jwt.Token) error {


### PR DESCRIPTION
## Summary
Corrects the typo `sucessfully` → `successfully` in the logout API response message.

## Fix
- File: `src/api/users.go` (line 332)
- Change: `"message": "logout sucessfully"` → `"message": "logout successfully"`